### PR TITLE
Update main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -198,7 +198,7 @@ void OpenLocalSocket()
     bzero(&localsock, sizeof(localsock));
 
     localsock.sun_family = AF_UNIX;    
-    memcpy(localsock.sun_path, gLocalAddress, 108);
+    memcpy(localsock.sun_path, gLocalAddress, sizeof(localsock.sun_path));
 
     // Connect the client socket to server socket
     if (connect(gLocal_fd, (SA*)&localsock, sizeof(localsock)) != 0) 


### PR DESCRIPTION
Fix crash on maces

For example, 4.3 BSD uses a size of 108, and 4.4 BSD uses a size of 104. Since most implementations originate from BSD versions, the size is typically in the range 92 to 108.

https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/un.h.html